### PR TITLE
Fix global variable in ceilIndex

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -938,7 +938,7 @@
 
     function ceilIndex(tail, l, r, val) {
         while (r - l > 1) {
-            m = l + Math.floor((r - l) / 2);
+            let m = l + Math.floor((r - l) / 2);
             if (val <= tail[m])
                 r = m;
             else


### PR DESCRIPTION
## Summary
- fix unintentional global by declaring `m` inside `ceilIndex`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847efca368c832aa31f092d00019dcf