### PR TITLE
Sanitize cloud loaded text

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -323,7 +323,7 @@
                         setSettings(true);
                     }
                     else{
-                        $('#teleprompter').html(response.teleprompter_text);
+                        $('#teleprompter').html(sanitizeText(response.teleprompter_text));
                         teleprompterUpdate();
                     }
                 } else {
@@ -631,8 +631,12 @@
 
         return randomstring;
     }
-    
-    
+
+    function sanitizeText(text){
+        return text.replace(/<script[\s\S]*?<\/script>/gi,'').replace(/<[^>]*>/g,'');
+    }
+
+
     function fullScreenEnter(){
         var elem = document.body;
         if (elem.requestFullscreen) {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "modern-teleprompter",
+  "version": "1.0.0",
+  "description": "A feature packed modern Teleprompter, with everything you need to read the text from a screen or teleprompter.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node test/sanitizeText.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/test/sanitizeText.test.js
+++ b/test/sanitizeText.test.js
@@ -1,0 +1,5 @@
+const assert = require('assert');
+const sanitizeText = (text) => text.replace(/<script[\s\S]*?<\/script>/gi, '').replace(/<[^>]*>/g, '');
+assert.strictEqual(sanitizeText('<p>Hello</p><script>alert(1)</script>'), 'Hello');
+assert.strictEqual(sanitizeText('Safe'), 'Safe');
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- sanitize downloaded text to avoid executing injected markup
- provide a regex-based helper for text sanitization
- add simple unit test for sanitizer
- setup npm test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848053d7ce0832a81889d6bdfdea793